### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["李敖", "wjm_tcy"]
 language = "zh"
-multilingual = false
 src = "./"
 title = "大李敖全集"
 


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10