### PR TITLE
fix: 修正 Cale Young Rice 诗句 OCR 误识

### DIFF
--- a/02.精品散文类/传统下的独白.md
+++ b/02.精品散文类/传统下的独白.md
@@ -1845,9 +1845,9 @@ You who are old，
 
 And have fought the fight，
 
-And have won or lost or left the fight，
+And have won or lost or left the field，
 
-Weight us not down，
+Weigh us not down，
 
 With fears of the world，as we run！
 


### PR DESCRIPTION
李敖《老年人和棒子》引用的 Cale Young Rice 诗歌《The Young to the Old》存在两处 OCR 误识，对照原诗集 _Nirvana Days_（1920）原文修正：

| 行 | 错误（OCR） | 正确（原文） |
|---|---|---|
| And have won or lost or left the… | **fight** | **field** |
| **Weight** us not down | Weight（名词） | **Weigh**（动词） |

原诗出处：https://classic-literature.net/cale-young-rice-1872-1943/nirvana-days/#THE_YOUNG_TO_THE_OLD